### PR TITLE
Remove extraneous args for gox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,5 +88,5 @@ clean:
 dev_bootstrap:
 	go get ./...
 	go get github.com/mitchellh/gox
-	gox -build-toolchain -osarch="linux/amd64" -osarch="darwin/amd64"
+	gox -osarch="linux/amd64" -osarch="darwin/amd64"
 	bundle install


### PR DESCRIPTION
The --build-toolchain arg is not required for go > 1.5 and causes the makefile to return an error.